### PR TITLE
feat: New parameter 'start' to Event executions for logging statistics purposes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,7 @@ name = "raikiri"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap 4.5.7",
  "clap_derive",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.86"
 clap = { version = "4.5.7", features = ["derive"] }
 clap_derive = { version = "4.5.5" }
+chrono = "0.4.33"
 futures = "0.3.30"
 homedir = "0.2.1"
 http = "1.1.0"

--- a/src/adapters/component_events.rs
+++ b/src/adapters/component_events.rs
@@ -17,7 +17,8 @@ pub fn default_event_handler(message: ComponentEvent) {
             if let Some(stdout) = stdout {
                 println!("Stdout from {username_component_name}: {}", String::from_utf8(stdout.contents().to_vec()).unwrap());
             }
-            println!("Started {username_component_name} at {start:#?} and finished in {duration}ms. Status code: {status}");
+            let start_text = start.to_rfc3339();
+            println!("Started {username_component_name} at {start_text} and finished in {duration}ms. Status code: {status}");
         }
     }
 }

--- a/src/adapters/component_events.rs
+++ b/src/adapters/component_events.rs
@@ -6,7 +6,7 @@ pub enum ComponentEvent {
         username_component_name: String,
         stdout: Option<MemoryOutputPipe>,
         start: DateTime<chrono::Utc>,
-        duration: u128,
+        duration: u64,
         status: u16
     }
 }

--- a/src/adapters/component_events.rs
+++ b/src/adapters/component_events.rs
@@ -1,9 +1,11 @@
 use wasmtime_wasi::pipe::MemoryOutputPipe;
+use chrono::DateTime;
 
 pub enum ComponentEvent {
     Execution {
         username_component_name: String,
         stdout: Option<MemoryOutputPipe>,
+        start: DateTime<chrono::Utc>,
         duration: u128,
         status: u16
     }
@@ -11,11 +13,11 @@ pub enum ComponentEvent {
 
 pub fn default_event_handler(message: ComponentEvent) {
     match message {
-        ComponentEvent::Execution { stdout, username_component_name, duration, status } => {
+        ComponentEvent::Execution { stdout, username_component_name, start, duration, status } => {
             if let Some(stdout) = stdout {
                 println!("Stdout from {username_component_name}: {}", String::from_utf8(stdout.contents().to_vec()).unwrap());
             }
-            println!("Finished {username_component_name} in {duration}ms. Status code: {status}");
+            println!("Started {username_component_name} at {start:#?} and finished in {duration}ms. Status code: {status}");
         }
     }
 }

--- a/src/adapters/component_invoke.rs
+++ b/src/adapters/component_invoke.rs
@@ -43,7 +43,7 @@ pub async fn invoke_component<T>(
                 stdout: None,
                 username_component_name,
                 start,
-                duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs().into(),
+                duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs(),
                 status: 400
             })
             .await.unwrap();
@@ -128,7 +128,7 @@ pub async fn invoke_component<T>(
             stdout: Some(stdout),
             username_component_name,
             start,
-            duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs().into(),
+            duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs(),
             status
         })
         .await.unwrap();

--- a/src/adapters/component_invoke.rs
+++ b/src/adapters/component_invoke.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use homedir::get_my_home;
     use http_body_util::{combinators::BoxBody, BodyExt};
@@ -33,8 +33,7 @@ pub async fn invoke_component<T>(
 ) -> Result<IncomingResponse, wasmtime_wasi_http::bindings::http::types::ErrorCode>
     where T: Send + Clone + RaikiriContext + 'static,
 {
-    let start = Instant::now();
-    let utc_start = chrono::Utc::now();
+    let start = chrono::Utc::now();
     let data = wasi.data.clone();
     let mut call_stack = data.call_stack().clone();
 
@@ -43,8 +42,8 @@ pub async fn invoke_component<T>(
             .send(ComponentEvent::Execution {
                 stdout: None,
                 username_component_name,
-                start: utc_start,
-                duration: start.elapsed().as_millis(),
+                start,
+                duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs().into(),
                 status: 400
             })
             .await.unwrap();
@@ -128,8 +127,8 @@ pub async fn invoke_component<T>(
         .send(ComponentEvent::Execution {
             stdout: Some(stdout),
             username_component_name,
-            start: utc_start,
-            duration: start.elapsed().as_millis(),
+            start,
+            duration: chrono::Utc::now().signed_duration_since(start).num_milliseconds().unsigned_abs().into(),
             status
         })
         .await.unwrap();


### PR DESCRIPTION
Output example with raikiri-hello-world:

![mensagem-started-event](https://github.com/user-attachments/assets/d819dbfd-34a9-4edd-b4ce-bcf6b632bb61)
